### PR TITLE
Clarify Colab usage and library role of roguelike_ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,18 @@ You can also run DungeonGPT in a Google Colab notebook:
    import os
    os.environ["OPENAI_API_KEY"] = "sk-..."
    ```
-4. **Run the game script:**
+4. **Use the library in a notebook cell** (`roguelike_ai.py` contains only library code and isn't executable on its own):
    ```python
-   !python roguelike_ai.py --seed 1337
+   from roguelike_ai import generate_dungeon, GameState, Player
+
+   rooms = generate_dungeon(seed=1337)
+   state = GameState(seed=1337, rooms=rooms, player=Player())
+   print(state.to_json())
    ```
 
 **Note:**
-- Colab notebooks are not ideal for interactive input. For best results, use the script in a terminal. If you want to play in Colab, you may need to adapt the code to use notebook cells for input/output.
+- `roguelike_ai.py` functions solely as a library. To play the game, run `roguelike_pygame.py` locally on a machine with a display.
+- Colab notebooks are not ideal for interactive input or graphics. If you want to experiment in Colab, adapt the code to use notebook cells for input/output.
 - The game requires an internet connection and a valid OpenAI API key.
 
 ## Commands


### PR DESCRIPTION
## Summary
- Update Colab instructions to use `roguelike_ai` as a library rather than a standalone script.
- Explain that `roguelike_ai.py` is library-only and point users to run `roguelike_pygame.py` for gameplay.

## Testing
- `python -m py_compile roguelike_ai.py roguelike_pygame.py`


------
https://chatgpt.com/codex/tasks/task_e_6892d184907c832f9bdc9be8c53016a5