### PR TITLE
Explicit boss room assignment

### DIFF
--- a/roguelike_ai.py
+++ b/roguelike_ai.py
@@ -45,7 +45,9 @@ ENEMIES = {
 }
 
 LOOT_TABLE = ["health potion", "silver key", "torch", "old map piece", "leather boots"]
-ROOM_TYPES = ["corridor", "treasure", "trap", "enemy_lair", "shrine", "boss_room", "locked"]
+# Note: "boss_room" is intentionally excluded; a boss room is assigned explicitly
+# during dungeon generation routines.
+ROOM_TYPES = ["corridor", "treasure", "trap", "enemy_lair", "shrine", "locked"]
 
 ROOM_TYPE_NAMES = {
     "EN": "Enemy Room",

--- a/roguelike_pygame.py
+++ b/roguelike_pygame.py
@@ -80,7 +80,8 @@ def generate_grid_dungeon(seed: int, grid_w: int = 6, grid_h: int = 6) -> dict:
                 rooms[room_id]["enemies"].append(enemy)
             if random.random() < 0.5:
                 rooms[room_id]["items"].append(random.choice(LOOT_TABLE))
-    # Place boss room at farthest cell
+    # Assign a boss room explicitly after all others are generated since
+    # "boss_room" is not part of ROOM_TYPES.
     boss_room = f"room_{grid_w*grid_h-1}"
     rooms[boss_room]["type"] = "boss_room"
     boss_enemy = {**ENEMIES["dungeon_boss"], "name": "dungeon_boss"}


### PR DESCRIPTION
## Summary
- remove `boss_room` from `ROOM_TYPES` constant
- note that boss rooms are assigned after generation in dungeon builders
- clarify boss room assignment in `generate_grid_dungeon`

## Testing
- `python -m py_compile roguelike_ai.py roguelike_pygame.py`
- `python - <<'PY'
from roguelike_ai import generate_dungeon
rooms=generate_dungeon(seed=123, n_rooms=10)
boss_rooms=[rid for rid, info in rooms.items() if info['type']=='boss_room']
print('boss rooms:', boss_rooms)
PY`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6892d17b0830832fa47ca5796b20650f