### PR TITLE
Refactor grid dungeon generation

### DIFF
--- a/core/dungeon.py
+++ b/core/dungeon.py
@@ -70,29 +70,3 @@ def generate_dungeon(seed: int, n_rooms: int = 12) -> Dict[str, dict]:
     return rooms
 
 
-def generate_grid_dungeon(seed: int, grid_w: int = 6, grid_h: int = 6) -> Dict[str, dict]:
-    """Generate a grid-based dungeon layout."""
-    random.seed(seed)
-    rooms: Dict[str, dict] = {}
-    for y in range(grid_h):
-        for x in range(grid_w):
-            room_id = f"room_{y * grid_w + x}"
-            r_type = random.choice(ROOM_TYPES if (x, y) != (0, 0) else ["entrance"])
-            rooms[room_id] = {
-                "type": r_type,
-                "coords": (x, y),
-                "visited": (x, y) == (0, 0),
-                "locked": r_type == "locked",
-                "trap": r_type == "trap" and random.randint(0, 1),
-                "enemies": [],
-                "items": [],
-            }
-            if r_type in {"enemy_lair", "corridor"} and random.random() < 0.6:
-                name = random.choice(list(ENEMIES)[:-1])
-                rooms[room_id]["enemies"].append({**ENEMIES[name], "name": name})
-            if random.random() < 0.5:
-                rooms[room_id]["items"].append(random.choice(LOOT_TABLE))
-    boss_room = f"room_{grid_w * grid_h - 1}"
-    rooms[boss_room]["type"] = "boss_room"
-    rooms[boss_room]["enemies"] = [{**ENEMIES["dungeon_boss"], "name": "dungeon_boss"}]
-    return rooms

--- a/core/grid.py
+++ b/core/grid.py
@@ -1,0 +1,37 @@
+"""Grid-based dungeon generation utilities."""
+
+from __future__ import annotations
+
+import random
+from typing import Dict
+
+from .data import ENEMIES, LOOT_TABLE, ROOM_TYPES
+
+
+def generate_grid_dungeon(seed: int, grid_w: int = 6, grid_h: int = 6) -> Dict[str, dict]:
+    """Generate a grid-based dungeon layout."""
+    random.seed(seed)
+    rooms: Dict[str, dict] = {}
+    for y in range(grid_h):
+        for x in range(grid_w):
+            room_id = f"room_{y * grid_w + x}"
+            r_type = random.choice(ROOM_TYPES if (x, y) != (0, 0) else ["entrance"])
+            rooms[room_id] = {
+                "type": r_type,
+                "coords": (x, y),
+                "visited": (x, y) == (0, 0),
+                "locked": r_type == "locked",
+                "trap": r_type == "trap" and random.randint(0, 1),
+                "enemies": [],
+                "items": [],
+            }
+            if r_type in {"enemy_lair", "corridor"} and random.random() < 0.6:
+                name = random.choice(list(ENEMIES)[:-1])
+                rooms[room_id]["enemies"].append({**ENEMIES[name], "name": name})
+            if random.random() < 0.5:
+                rooms[room_id]["items"].append(random.choice(LOOT_TABLE))
+    boss_room = f"room_{grid_w * grid_h - 1}"
+    rooms[boss_room]["type"] = "boss_room"
+    rooms[boss_room]["enemies"] = [{**ENEMIES["dungeon_boss"], "name": "dungeon_boss"}]
+    return rooms
+

--- a/ui/game_loop.py
+++ b/ui/game_loop.py
@@ -14,7 +14,7 @@ def run():
         attack_enemy,
     )
 
-    from core.dungeon import generate_grid_dungeon
+    from core.grid import generate_grid_dungeon
     from core.models import Player, GameState
     from ai import handle_command, get_api_call_counter
     from ui.dialogs import select_hero, game_over_dialog, HERO_STATS


### PR DESCRIPTION
## Summary
- move grid-based dungeon generation into a dedicated `core.grid` module
- update game loop to import dungeon generator from the new module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68949e5b52d0832f9a19a6517c726492