### PR TITLE
chore: update model to gpt-5-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can also type natural language commands (e.g., `Go north`, `Attack the gobli
 ## Notes
 - The game requires an internet connection to communicate with OpenAI.
 - The virtual environment (`.venv`) is provided but you must install `openai` yourself.
-- The default model is `gpt-4.1-mini` (change with `--model` if needed).
+- The default model is `gpt-5-mini` (change with `--model` if needed).
 
 ## Credits
 - Some visual assets and inspiration from [2-Minute Tabletop](https://tools.2minutetabletop.com/)

--- a/ui/game_loop.py
+++ b/ui/game_loop.py
@@ -398,7 +398,7 @@ def run():
                 import contextlib
                 buf = io.StringIO()
                 with contextlib.redirect_stdout(buf):
-                    result = handle_command(pending_command, state, "gpt-4.1-mini", roll_result_to_send, None)
+                    result = handle_command(pending_command, state, "gpt-5-mini", roll_result_to_send, None)
                 narrative = ""
                 options = []
                 force_option_select = False
@@ -513,7 +513,7 @@ def run():
                 import contextlib
                 buf = io.StringIO()
                 with contextlib.redirect_stdout(buf):
-                    result = handle_command(pending_command, state, "gpt-4.1-mini", roll_result_to_send, None)
+                    result = handle_command(pending_command, state, "gpt-5-mini", roll_result_to_send, None)
                 narrative = ""
                 options = []
                 force_option_select = False


### PR DESCRIPTION
## Summary
- Use `gpt-5-mini` model by default during gameplay
- Mention `gpt-5-mini` as the default model in documentation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894ee53f1bc832fbf65de6b140d66fd