### PR TITLE
Use Responses API with reasoning for gpt-5-mini

### DIFF
--- a/ai/__init__.py
+++ b/ai/__init__.py
@@ -6,7 +6,7 @@ import json
 import os
 from dataclasses import asdict
 
-import openai
+from openai import OpenAI
 
 from core.models import GameState, Player
 from core.dungeon import deep_update
@@ -81,6 +81,9 @@ SYSTEM_PROMPT = (
 # Add a counter to track API calls
 api_call_counter = 1
 
+# Initialize OpenAI client lazily
+client: OpenAI | None = None
+
 
 def call_openai(state: GameState, cmd: str, model: str, roll_result: int | None = None) -> dict:
     """Send state and command to OpenAI and return the parsed response."""
@@ -88,9 +91,13 @@ def call_openai(state: GameState, cmd: str, model: str, roll_result: int | None 
     api_call_counter += 1  # Increment the counter
 
     # Ensure OpenAI API key is set
-    openai.api_key = os.getenv("OPENAI_API_KEY")
-    if not openai.api_key:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
         raise ValueError("OpenAI API key is not set. Please check your environment variables.")
+
+    global client
+    if client is None:
+        client = OpenAI(api_key=api_key)
 
     # Pass history as context for memory
     messages = [
@@ -102,12 +109,18 @@ def call_openai(state: GameState, cmd: str, model: str, roll_result: int | None 
             "history": state.history[-10:]  # Last 10 events for context
         })},
     ]
-    resp = openai.chat.completions.create(
+    resp = client.responses.create(
         model=model,
-        messages=messages,
+        input=messages,
         temperature=0.7,
+        reasoning={"effort": "minimal"},
     )
-    content = resp.choices[0].message.content
+    content = ""
+    for item in resp.output:
+        if item.type == "message":
+            for c in item.content:
+                if c.type == "output_text":
+                    content += c.text
     try:
         return json.loads(content)
     except json.JSONDecodeError:


### PR DESCRIPTION
## Summary
- use OpenAI Responses API for game narration
- enable reasoning with minimal effort for `gpt-5-mini`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894faa339a4832fb3316e5474416b1a